### PR TITLE
Add module pause/resume on blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Click the banner below and sign up to **Bytes**, the only newsletter cool enough
 - Real-time system (CPU, RAM, swap, processes) and network (GeoIP, active connections, transfer rates) monitoring.
 - Full support for touch-enabled displays, including an on-screen keyboard.
 - Directory viewer that follows the CWD (current working directory) of the terminal.
+- Automatically pauses monitoring modules when the window loses focus and resumes when focus returns.
 - Advanced customization using themes, on-screen keyboard layouts, CSS injections. See the [wiki](https://github.com/GitSquared/edex-ui/wiki) for more info.
 - Optional sound effects made by a talented sound designer for maximum hollywood hacking vibe.
 

--- a/src/_renderer.js
+++ b/src/_renderer.js
@@ -1150,3 +1150,19 @@ electronWin.on("resize", () => {
 electronWin.on("leave-full-screen", () => {
     electron.remote.getCurrentWindow().setSize(960, 540);
 });
+
+electronWin.on("blur", () => {
+    if (window.mods) {
+        Object.values(window.mods).forEach(mod => {
+            if (typeof mod.pause === "function") mod.pause();
+        });
+    }
+});
+
+electronWin.on("focus", () => {
+    if (window.mods) {
+        Object.values(window.mods).forEach(mod => {
+            if (typeof mod.resume === "function") mod.resume();
+        });
+    }
+});

--- a/src/classes/clock.class.js
+++ b/src/classes/clock.class.js
@@ -18,6 +18,20 @@ class Clock {
             this.updateClock();
         }, 1000);
     }
+    pause() {
+        if (this.updater) {
+            clearInterval(this.updater);
+            this.updater = null;
+        }
+    }
+    resume() {
+        if (!this.updater) {
+            this.updateClock();
+            this.updater = setInterval(() => {
+                this.updateClock();
+            }, 1000);
+        }
+    }
     updateClock() {
         let time = new Date();
         let array = [time.getHours(), time.getMinutes(), time.getSeconds()];

--- a/src/classes/conninfo.class.js
+++ b/src/classes/conninfo.class.js
@@ -61,6 +61,20 @@ class Conninfo {
             this.updateInfo();
         }, 1000);
     }
+    pause() {
+        if (this.infoUpdater) {
+            clearInterval(this.infoUpdater);
+            this.infoUpdater = null;
+        }
+    }
+    resume() {
+        if (!this.infoUpdater) {
+            this.updateInfo();
+            this.infoUpdater = setInterval(() => {
+                this.updateInfo();
+            }, 1000);
+        }
+    }
     updateInfo() {
         let time = new Date().getTime();
 

--- a/src/classes/cpuinfo.class.js
+++ b/src/classes/cpuinfo.class.js
@@ -120,6 +120,50 @@ class Cpuinfo {
             }, 5000);
         });
     }
+    pause() {
+        if (this.loadUpdater) {
+            clearInterval(this.loadUpdater);
+            this.loadUpdater = null;
+        }
+        if (this.tempUpdater) {
+            clearInterval(this.tempUpdater);
+            this.tempUpdater = null;
+        }
+        if (this.speedUpdater) {
+            clearInterval(this.speedUpdater);
+            this.speedUpdater = null;
+        }
+        if (this.tasksUpdater) {
+            clearInterval(this.tasksUpdater);
+            this.tasksUpdater = null;
+        }
+    }
+    resume() {
+        if (!this.loadUpdater) {
+            this.updateCPUload();
+            this.loadUpdater = setInterval(() => {
+                this.updateCPUload();
+            }, 500);
+        }
+        if (process.platform !== "win32" && !this.tempUpdater) {
+            this.updateCPUtemp();
+            this.tempUpdater = setInterval(() => {
+                this.updateCPUtemp();
+            }, 2000);
+        }
+        if (!this.speedUpdater) {
+            this.updateCPUspeed();
+            this.speedUpdater = setInterval(() => {
+                this.updateCPUspeed();
+            }, 1000);
+        }
+        if (!this.tasksUpdater) {
+            this.updateCPUtasks();
+            this.tasksUpdater = setInterval(() => {
+                this.updateCPUtasks();
+            }, 5000);
+        }
+    }
     updateCPUload() {
         if (this.updatingCPUload) return;
         this.updatingCPUload = true;

--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -66,6 +66,24 @@ class FilesystemDisplay {
             }
         }, 1000);
 
+        this.pause = () => {
+            if (this._timer) {
+                clearInterval(this._timer);
+                this._timer = null;
+            }
+        };
+
+        this.resume = () => {
+            if (!this._timer) {
+                this._timer = setInterval(() => {
+                    if (this._runNextTick === true) {
+                        this._runNextTick = false;
+                        this.readFS(this.dirpath);
+                    }
+                }, 1000);
+            }
+        };
+
         this._asyncFSwrapper = new Proxy(fs, {
             get: function(fs, prop) {
                 if (prop in fs) {

--- a/src/classes/hardwareInspector.class.js
+++ b/src/classes/hardwareInspector.class.js
@@ -28,6 +28,20 @@ class HardwareInspector {
             this.updateInfo();
         }, 20000);
     }
+    pause() {
+        if (this.infoUpdater) {
+            clearInterval(this.infoUpdater);
+            this.infoUpdater = null;
+        }
+    }
+    resume() {
+        if (!this.infoUpdater) {
+            this.updateInfo();
+            this.infoUpdater = setInterval(() => {
+                this.updateInfo();
+            }, 20000);
+        }
+    }
     updateInfo() {
         window.si.system().then(d => {
             window.si.chassis().then(e => {

--- a/src/classes/locationGlobe.class.js
+++ b/src/classes/locationGlobe.class.js
@@ -133,6 +133,32 @@ class LocationGlobe {
         }, 4000);
     }
 
+    pause() {
+        if (this.locUpdater) {
+            clearInterval(this.locUpdater);
+            this.locUpdater = null;
+        }
+        if (this.connsUpdater) {
+            clearInterval(this.connsUpdater);
+            this.connsUpdater = null;
+        }
+    }
+
+    resume() {
+        if (!this.locUpdater) {
+            this.updateLoc();
+            this.locUpdater = setInterval(() => {
+                this.updateLoc();
+            }, 1000);
+        }
+        if (!this.connsUpdater) {
+            this.updateConns();
+            this.connsUpdater = setInterval(() => {
+                this.updateConns();
+            }, 3000);
+        }
+    }
+
     addRandomConnectedMarkers() {
         const randomLat = this.getRandomInRange(40, 90, 3);
         const randomLong = this.getRandomInRange(-180, 0, 3);

--- a/src/classes/netstat.class.js
+++ b/src/classes/netstat.class.js
@@ -41,6 +41,26 @@ class Netstat {
             this.updateInfo();
         }, 2000);
 
+        this.paused = false;
+
+        this.pause = () => {
+            if (this.infoUpdater) {
+                clearInterval(this.infoUpdater);
+                this.infoUpdater = null;
+                this.paused = true;
+            }
+        };
+
+        this.resume = () => {
+            if (!this.infoUpdater) {
+                this.updateInfo();
+                this.infoUpdater = setInterval(() => {
+                    this.updateInfo();
+                }, 2000);
+                this.paused = false;
+            }
+        };
+
         // Init GeoIP integrated backend
         this.geoLookup = {
             get: () => null

--- a/src/classes/ramwatcher.class.js
+++ b/src/classes/ramwatcher.class.js
@@ -35,6 +35,20 @@ class RAMwatcher {
             this.updateInfo();
         }, 1500);
     }
+    pause() {
+        if (this.infoUpdater) {
+            clearInterval(this.infoUpdater);
+            this.infoUpdater = null;
+        }
+    }
+    resume() {
+        if (!this.infoUpdater) {
+            this.updateInfo();
+            this.infoUpdater = setInterval(() => {
+                this.updateInfo();
+            }, 1500);
+        }
+    }
     updateInfo() {
         if (this.currentlyUpdating) return;
         this.currentlyUpdating = true;

--- a/src/classes/sysinfo.class.js
+++ b/src/classes/sysinfo.class.js
@@ -45,6 +45,38 @@ class Sysinfo {
         this.batteryUpdater = setInterval(() => {
             this.updateBattery();
         }, 3000);
+        this.dateTimeout = null;
+    }
+    pause() {
+        if (this.uptimeUpdater) {
+            clearInterval(this.uptimeUpdater);
+            this.uptimeUpdater = null;
+        }
+        if (this.batteryUpdater) {
+            clearInterval(this.batteryUpdater);
+            this.batteryUpdater = null;
+        }
+        if (this.dateTimeout) {
+            clearTimeout(this.dateTimeout);
+            this.dateTimeout = null;
+        }
+    }
+    resume() {
+        if (!this.uptimeUpdater) {
+            this.updateUptime();
+            this.uptimeUpdater = setInterval(() => {
+                this.updateUptime();
+            }, 60000);
+        }
+        if (!this.batteryUpdater) {
+            this.updateBattery();
+            this.batteryUpdater = setInterval(() => {
+                this.updateBattery();
+            }, 3000);
+        }
+        if (!this.dateTimeout) {
+            this.updateDate();
+        }
     }
     updateDate() {
         let time = new Date();
@@ -93,7 +125,7 @@ class Sysinfo {
         document.querySelector("#mod_sysinfo > div:first-child > h2").innerHTML = month+" "+time.getDate();
 
         let timeToNewDay = ((23 - time.getHours()) * 3600000) + ((59 - time.getMinutes()) * 60000);
-        setTimeout(() => {
+        this.dateTimeout = setTimeout(() => {
             this.updateDate();
         }, timeToNewDay);
     }

--- a/src/classes/toplist.class.js
+++ b/src/classes/toplist.class.js
@@ -19,6 +19,20 @@ class Toplist {
             this.updateList();
         }, 2000);
     }
+    pause() {
+        if (this.listUpdater) {
+            clearInterval(this.listUpdater);
+            this.listUpdater = null;
+        }
+    }
+    resume() {
+        if (!this.listUpdater) {
+            this.updateList();
+            this.listUpdater = setInterval(() => {
+                this.updateList();
+            }, 2000);
+        }
+    }
     updateList() {
         if (this.currentlyUpdating) return;
 


### PR DESCRIPTION
## Summary
- add pause/resume methods for each module that uses intervals
- stop and start modules when the window loses or regains focus
- describe the new pause/resume behaviour in the README

## Testing
- `npm test` *(fails: cannot find module 'terser')*

------
https://chatgpt.com/codex/tasks/task_b_6855e1706a70832582faf33c81cc6fc4